### PR TITLE
Fix logo underline

### DIFF
--- a/frontend/stylesheets/navbar.scss
+++ b/frontend/stylesheets/navbar.scss
@@ -5,7 +5,7 @@
   flex: 1;
   margin-left: 20px;
 
-  &:hover {
+  &, &:hover {
     text-decoration: none;
   }
 
@@ -18,7 +18,6 @@
     text-transform: none;
     color: $white;
     font-size: 40px;
-    text-decoration: none;
   }
 }
 


### PR DESCRIPTION
Previously showed underline on Chrome after clicking the logo.