### PR TITLE
Increase the size and add a drop-shadow

### DIFF
--- a/frontend/stylesheets/styles.scss
+++ b/frontend/stylesheets/styles.scss
@@ -174,8 +174,10 @@ div#not-implemented {
   }
 
   &__logo {
-    height: 66px;
+    height: 130px;
     margin-bottom: 20px;
+    filter: drop-shadow(15px 15px 40px #111);
+    -webkit-filter: drop-shadow(15px 15px 40px #111);
   }
 
   &__admin-link {


### PR DESCRIPTION
Tested on Safari 10 and Chrome 59.  Will test FF and IE (which most likely won't suppor this) when deployed.