### PR TITLE
Enable Ansible SSH pipelining

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,6 @@
+[defaults]
+# Uncomment to profile
+# callback_whitelist = profile_tasks
+
+[ssh_connection]
+pipelining = True


### PR DESCRIPTION
Makes copying files blazingly fast.