### PR TITLE
Add translations to workstatus

### DIFF
--- a/frontend/Profile/View.elm
+++ b/frontend/Profile/View.elm
@@ -806,10 +806,10 @@ workStatusSelect t user =
     H.span
         [ A.class "user-page__location-select-container" ]
         [ H.select
-            [ E.on "change" (Json.map (ChangeWorkStatus << WorkStatus.fromString) E.targetValue)
+            [ E.on "change" (Json.map (ChangeWorkStatus << WorkStatus.fromString t) E.targetValue)
             , A.class "user-page__location-select"
             ]
-            (List.map (optionPreselected (user.workStatus |> Maybe.map (WorkStatus.toString t) |> Maybe.withDefault "")) ("" :: Config.workStatuses))
+            (List.map (optionPreselected (user.workStatus |> Maybe.map (WorkStatus.toString t) |> Maybe.withDefault "")) ("" :: Config.workStatuses t))
         ]
 
 

--- a/frontend/Profile/View.elm
+++ b/frontend/Profile/View.elm
@@ -809,7 +809,7 @@ workStatusSelect t user =
             [ E.on "change" (Json.map (ChangeWorkStatus << WorkStatus.fromString t) E.targetValue)
             , A.class "user-page__location-select"
             ]
-            (List.map (optionPreselected (user.workStatus |> Maybe.map (WorkStatus.toString t) |> Maybe.withDefault "")) ("" :: Config.workStatuses t))
+            (List.map (optionPreselected (user.workStatus |> Maybe.map (WorkStatus.toString t) |> Maybe.withDefault "")) ("" :: List.map (WorkStatus.toString t) Config.workStatuses))
         ]
 
 

--- a/frontend/State/Config.elm
+++ b/frontend/State/Config.elm
@@ -5,6 +5,7 @@ import Json.Decode as Json
 import Json.Decode.Pipeline as P
 import Json.Encode as JS
 import Translation exposing (T)
+import WorkStatus
 
 
 type alias Model =
@@ -99,8 +100,8 @@ finnishRegions =
     ]
 
 
-workStatuses : T -> List String
-workStatuses t =
-    [ t "workStatus.working"
-    , t "workStatus.on_leave"
+workStatuses : List WorkStatus.WorkStatus
+workStatuses =
+    [ WorkStatus.Working
+    , WorkStatus.OnLeave
     ]

--- a/frontend/State/Config.elm
+++ b/frontend/State/Config.elm
@@ -4,6 +4,7 @@ import Dict exposing (Dict)
 import Json.Decode as Json
 import Json.Decode.Pipeline as P
 import Json.Encode as JS
+import Translation exposing (T)
 
 
 type alias Model =
@@ -98,8 +99,8 @@ finnishRegions =
     ]
 
 
-workStatuses : List String
-workStatuses =
-    [ "Työelämässä"
-    , "Vapaalla"
+workStatuses : T -> List String
+workStatuses t =
+    [ t "workStatus.working"
+    , t "workStatus.on_leave"
     ]

--- a/frontend/WorkStatus.elm
+++ b/frontend/WorkStatus.elm
@@ -13,10 +13,10 @@ toString : T -> WorkStatus -> String
 toString t workStatus =
     case workStatus of
         Working ->
-            "Työelämässä"
+            t "workStatus.working"
 
         OnLeave ->
-            "Vapaalla"
+            t "workStatus.on_leave"
 
 
 toApiString : WorkStatus -> String
@@ -29,17 +29,14 @@ toApiString workStatus =
             "on_leave"
 
 
-fromString : String -> Maybe WorkStatus
-fromString str =
-    case str of
-        "Työelämässä" ->
-            Just Working
-
-        "Vapaalla" ->
-            Just OnLeave
-
-        _ ->
-            Nothing
+fromString : T -> String -> Maybe WorkStatus
+fromString t str =
+    if str == t "workStatus.working" then
+        Just Working
+    else if str == t "workStatus.on_leave" then
+        Just OnLeave
+    else
+        Nothing
 
 
 decoder : Decoder WorkStatus

--- a/frontend/js/translations.js
+++ b/frontend/js/translations.js
@@ -349,6 +349,10 @@ const source = {
       submit: 'Lähetä',
     },
   },
+  workStatus: {
+    on_leave: 'Vapaalla',
+    working: 'Työelämässä',
+  },
 };
 
 


### PR DESCRIPTION
Had to change "case str" to "if str ==" in WorkStatus.elm. Not sure if case can be used there.

Switched from strings to WorkStatus types in Config.elm. Feels more robust.